### PR TITLE
update to getObjectStack

### DIFF
--- a/src/main/java/com/coxspecialloothider/CoxSpecialLootHiderPlugin.java
+++ b/src/main/java/com/coxspecialloothider/CoxSpecialLootHiderPlugin.java
@@ -118,12 +118,12 @@ public class CoxSpecialLootHiderPlugin extends Plugin
 
 		int[] intStack = client.getIntStack();
 		int intStackSize = client.getIntStackSize();
-		String[] stringStack = client.getStringStack();
-		int stringStackSize = client.getStringStackSize();
+		Object[] objectStack = client.getObjectStack();
+		int objectStackSize = client.getObjectStackSize();
 
 		final int messageType = intStack[intStackSize - 2];
 		final int messageId = intStack[intStackSize - 1];
-		String message = stringStack[stringStackSize - 1];
+		String message = (String) objectStack[objectStackSize - 1];
 
 		ChatMessageType chatMessageType = ChatMessageType.of(messageType);
 		final MessageNode messageNode = client.getMessages().get(messageId);


### PR DESCRIPTION
The API 231 update in June replaced `Client::getStringStack` with `Client::getObjectStack`, rendering this plugin unavailable. This patch switches to the new API and gets it working again.

Example of another plugin doing this same migration: https://github.com/i/rl-plugins/compare/61bf3de1500c68bc7015f0f727831aba3ff5b819...i:9aafd2f67efeccecb4dcc2478d7fea8aaed4e317

**It was not really feasible for me to run CoX and get a purple to test this so I did not do so.**